### PR TITLE
Crosshair Übersetzung fehlt

### DIFF
--- a/de_de.json
+++ b/de_de.json
@@ -271,6 +271,7 @@
   "nrc.ui.modules.value.vertical" : "Vertikal",
   "nrc.ui.modules.value.weather" : "Wetter",
   "nrc.ui.modules.value.width" : "Breite",
+  "nrc.ui.modules.value.height": "Höhe",
   "nrc.ui.modules.value.zoomInDuration" : "Einzoom-Dauer",
   "nrc.ui.modules.value.zoomKey" : "Zoom-Taste",
   "nrc.ui.modules.value.zoomOutDuration" : "Auszoom-Dauer",

--- a/en_us.json
+++ b/en_us.json
@@ -297,6 +297,7 @@
   "nrc.ui.modules.value.vertical" : "Vertical",
   "nrc.ui.modules.value.weather" : "Weather",
   "nrc.ui.modules.value.width" : "Width",
+  "nrc.ui.modules.value.height": "Height",
   "nrc.ui.modules.value.zoomInDuration" : "Zoom In Duration",
   "nrc.ui.modules.value.zoomKey" : "Zoom Key",
   "nrc.ui.modules.value.zoomOutDuration" : "Zoom Out Duration",


### PR DESCRIPTION
Die Übersetzung "nrc.ui.modules.value.height" hat bei "en_us" sowie "de_de" gefehlt.